### PR TITLE
This PR changes the default port to 8081, and adds parentLicense property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Folio service module - licenses
 ## Regenerating the liquibase migrations script
 
 grails -Dgrails.env=dbGen dbm-generate-gorm-changelog my-new-changelog.groovy
+
+## Troubleshooting
+
+This module runs on port 8081 when run from the run_external_reg.sh script, and this port is the assumed default for the deployment descriptor. This is so that 
+module developers can run mod_erm and mod_licenses side by side in development mode.

--- a/scripts/create_test_data.sh
+++ b/scripts/create_test_data.sh
@@ -13,14 +13,14 @@ fi
 echo Running
 
 echo get licenses config
-curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/kiwt/config
+curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/kiwt/config
 
 echo Load test config
-curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/config -d @license_properties.json
+curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/config -d @license_properties.json
 
 echo Fetch value list for YNO
 ## This will retrieve a JSON document describing the YNO category and all it's values
-YNO_CAT_VALUES=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/refdataValues?filters='owner.desc%3D%3DYNO'\&sort=value`
+YNO_CAT_VALUES=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/refdataValues?filters='owner.desc%3D%3DYNO'\&sort=value`
 YNO_CAT_ID=`echo $YNO_CAT_VALUES | jq -r ".[0].owner.id" | tr -d '\r'`
 YNO_NO_ID=`echo $YNO_CAT_VALUES | jq -r ".[0].id" | tr -d '\r'`
 YNO_OTHER_ID=`echo $YNO_CAT_VALUES | jq -r ".[1].id" | tr -d '\r'`
@@ -28,13 +28,13 @@ YNO_YES_ID=`echo $YNO_CAT_VALUES | jq -r ".[2].id" | tr -d '\r'`
 echo KEYS for refdata - YNO Category $YNO_CAT_ID - No=$YNO_NO_ID Yes=$YNO_YES_ID Other=$YNO_OTHER_ID
 
 echo Looking up WalkInAccess property
-PROP_WIA=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/custprops?filters='name%3D%3DWalkInAccess' | jq -r ".[0].id"`
-PROP_LIC_LOC=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/custprops?filters='name%3D%3DlicenseLocation' | jq -r ".[0].id"`
-PROP_INT=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/custprops?filters='name%3D%3DaIntegerProp' | jq -r ".[0].id"`
-PROP_DEC=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/custprops?filters='name%3D%3DaDecimalProp' | jq -r ".[0].id"`
+PROP_WIA=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/custprops?filters='name%3D%3DWalkInAccess' | jq -r ".[0].id"`
+PROP_LIC_LOC=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/custprops?filters='name%3D%3DlicenseLocation' | jq -r ".[0].id"`
+PROP_INT=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/custprops?filters='name%3D%3DaIntegerProp' | jq -r ".[0].id"`
+PROP_DEC=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/custprops?filters='name%3D%3DaDecimalProp' | jq -r ".[0].id"`
 
 echo Create test licenses
-TEST_LICENSE_1=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_1=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "Test License 001",
   description: "This is a test licenses",
@@ -51,7 +51,7 @@ TEST_LICENSE_1=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
   ]
 } ' | jq -r ".id"`
 
-TEST_LICENSE_2=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_2=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "Test License 002",
   tags: [
@@ -59,7 +59,7 @@ TEST_LICENSE_2=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
   ]
 } ' | jq -r ".id"`
 
-TEST_LICENSE_3=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_3=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "Test License 003",
   tags: [
@@ -67,7 +67,7 @@ TEST_LICENSE_3=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
   ]
 } ' | jq -r ".id"`
 
-TEST_LICENSE_4=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_4=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "BMJ Journals Online 2011-2012 NESLi2",
   tags: [
@@ -75,7 +75,7 @@ TEST_LICENSE_4=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
   ]
 } ' | jq -r ".id"`
 
-TEST_LICENSE_5=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_5=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "Academic Rights Press/Test Consortium/InteLex Collections - Perpetual Purchase Agreement",
   tags: [
@@ -83,7 +83,7 @@ TEST_LICENSE_5=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
   ]
 } ' | jq -r ".id"`
 
-TEST_LICENSE_6=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/licenses/licenses -d '
+TEST_LICENSE_6=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8081/licenses/licenses -d '
 {
   name: "American Association for the Advancement of Science/NESLi2/Science Classic/2014-2114",
   description: "AAA/NESLi2 consortial license. DIKU University is a signatory to this consortial license",
@@ -93,4 +93,4 @@ TEST_LICENSE_6=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: applicati
 } ' | jq -r ".id"`
 
 echo Retrieve license 1
-curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8080/licenses/licenses/$TEST_LICENSE_1
+curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X GET http://localhost:8081/licenses/licenses/$TEST_LICENSE_1

--- a/scripts/license_properties.json
+++ b/scripts/license_properties.json
@@ -27,7 +27,7 @@
     { "propname":"AlumniAccess", "type":"RDV", "category":"YNO" },
     { "propname":"TextAndDatMining", "type":"RDV", "category":"YNO" },
     { "propname":"allRightsReserved", "type":"String" },
-    { "propname":"applicabaleCopyrightLaw", "type":"String" },
+    { "propname":"applicableCopyrightLaw", "type":"String" },
     { "propname":"archivingAllowed", "type":"RDV", "category":"YNO" },
     { "propname":"archivingFormat", "type":"String" },
     { "propname":"confidentialityofAgreementRequired", "type":"RDV", "category":"YNO" },

--- a/scripts/run_external_reg.sh
+++ b/scripts/run_external_reg.sh
@@ -2,5 +2,5 @@
 
 echo Start mod-licenses in external-register mode
 
-java -jar build/libs/mod-licenses-1.0.jar -Xmx1G --grails.server.host=10.0.2.2 --dataSource.username=folio_admin --dataSource.password=folio_admin --dataSource.url=jdbc:postgresql://localhost:54321/okapi_modules
+java -jar build/libs/mod-licenses-1.0.jar -Xmx1G --server.port=8081 --grails.server.host=10.0.2.2 --dataSource.username=folio_admin --dataSource.password=folio_admin --dataSource.url=jdbc:postgresql://localhost:54321/okapi_modules
 

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -1,7 +1,4 @@
 ---
-server:
-  port: 8081
----
 grails:
     profile: rest-api
     codegen:
@@ -157,8 +154,6 @@ environments:
         abandonWhenPercentageFull: 50
         jdbcInterceptors: ConnectionState
         defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
-    server:
-      port: 8080
 ---
 okapi:
   schema:

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -157,6 +157,8 @@ environments:
         abandonWhenPercentageFull: 50
         jdbcInterceptors: ConnectionState
         defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+    server:
+      port: 8080
 ---
 okapi:
   schema:

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -1,4 +1,7 @@
 ---
+server:
+  port: 8081
+---
 grails:
     profile: rest-api
     codegen:

--- a/service/grails-app/domain/org/olf/licenses/License.groovy
+++ b/service/grails-app/domain/org/olf/licenses/License.groovy
@@ -11,6 +11,7 @@ class License implements MultiTenant<License> {
   String id
   String name
   String description
+  License parent
 
 // allRightsReserved 
 // applicabaleCopyrightLaw 
@@ -65,6 +66,7 @@ class License implements MultiTenant<License> {
   static constraints = {
            name(nullable:false, blank:false)
     description(nullable:true, blank:false)
+         parent(nullable:true, blank:false)
   }
 
   static mapping = {
@@ -72,6 +74,7 @@ class License implements MultiTenant<License> {
            name column: 'lic_name'
     description column: 'lic_description'
         version column: 'lic_version'
+         parent column: 'lic_parent_fk'
   }
 
 }

--- a/service/grails-app/migrations/create-mod-license.groovy
+++ b/service/grails-app/migrations/create-mod-license.groovy
@@ -27,6 +27,8 @@ databaseChangeLog = {
             }
 
             column(name: "lic_description", type: "VARCHAR(255)")
+
+            column(name: "lic_parent_fk", type: "VARCHAR(36)")
         }
     }
 

--- a/service/src/main/okapi/DeploymentDescriptor-template.json
+++ b/service/src/main/okapi/DeploymentDescriptor-template.json
@@ -1,5 +1,5 @@
 {
   "srvcId": "${info.app.name}-${info.app.version}",
   "instId": "10.0.2.2-${info.app.name}-${info.app.version}",
-  "url": "http://10.0.2.2:8080/"
+  "url": "http://10.0.2.2:8081/"
 }


### PR DESCRIPTION
Update the deployment descriptor to use port 8081
Update the run_external_reg.sh script to use --server.port=8081
Add parent property to license to model the scenario where a consortial member copies a consortial license and signs their copy - mostly as a test case for ui-plugin-find-license
