### PR TITLE
Change license resource so links are not included by default, provide licenseLinks endpoint instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ be made hierarchical by having a module.resource-type structure - this would all
 
 Postel's law is the way here: Be conservative in what you do, be liberal in what you accept from others.
 
+As of Monday 2019-01-28, we no longer include an expanded list of licenseLinks in the returned license object. There may be 10s of 000s of license links and this would be a 
+heavy payload to drop on an unsuspecting client. Clients will therefore need to query the /licenses/licenseLinks endpoint and filter by owner==UUID_OF_LICENSE in order to enumerate
+the list of things a license might be linked to. This will give you full control over pagination, but prevent you from easily getting hold of the linked items in a default call.
+
 ## Create a license
 
 Post a json document that takes properties as defined in the [license domain class](https://github.com/folio-org/mod-licenses/blob/master/service/grails-app/domain/org/olf/licenses/License.groovy) and creates a new license.

--- a/service/grails-app/controllers/org/olf/licenses/LicenseLinkController.groovy
+++ b/service/grails-app/controllers/org/olf/licenses/LicenseLinkController.groovy
@@ -1,0 +1,25 @@
+package org.olf.licenses
+
+import grails.gorm.multitenancy.CurrentTenant
+import groovy.util.logging.Slf4j
+
+import org.olf.licenses.LicenseLink
+
+import com.k_int.okapi.OkapiTenantAwareController
+
+import grails.converters.JSON
+
+
+/**
+ * Control access to subscription agreements.
+ * A subscription agreement (SA) is the connection between a set of resources (Which could be packages or individual titles) and a license. 
+ * SAs have start dates, end dates and renewal dates. This controller exposes functions for interacting with the list of SAs
+ */
+@CurrentTenant
+class LicenseLinkController extends OkapiTenantAwareController<LicenseLink>  {
+
+  LicenseLinkController() {
+    super(LicenseLink)
+  }
+}
+

--- a/service/grails-app/controllers/org/olf/licenses/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/licenses/UrlMappings.groovy
@@ -6,6 +6,7 @@ class UrlMappings {
 
     "/"(controller: 'application', action:'index')
     "/licenses/licenses"(resources:'license')
+    "/licenses/licenseLinks"(resources:'licenseLink')
 
     '/licenses/refdata'(resources: 'refdata') {
       collection {

--- a/service/grails-app/views/license/_license.gson
+++ b/service/grails-app/views/license/_license.gson
@@ -3,4 +3,4 @@ import org.olf.licenses.License
 import groovy.transform.*
 
 @Field License license
-json g.render(license, [expand: ['licenseProps','tags', 'customProperties', 'links', 'status', 'type' ]])
+json g.render(license, [expand: ['licenseProps','tags', 'customProperties', 'status', 'type' ]])


### PR DESCRIPTION
Change to address the large cardinality of license links.