### PR TITLE
ERM-7 LicenseOrg: Expand necessary fields

### DIFF
--- a/service/grails-app/views/license/_license.gson
+++ b/service/grails-app/views/license/_license.gson
@@ -3,7 +3,7 @@ import org.olf.licenses.License
 import groovy.transform.*
 
 @Field License license
-json g.render(license, [expand: ['licenseProps','tags', 'customProperties', 'status', 'type' ]]) {
+json g.render(license, [expand: ['licenseProps','tags', 'customProperties', 'status', 'type', 'orgs' ]]) {
   _links {
     linkedResources {
       href "/licenses/licenseLinks?filter=owner.id%3d${license.id}"

--- a/service/grails-app/views/licenseOrg/_licenseOrg.gson
+++ b/service/grails-app/views/licenseOrg/_licenseOrg.gson
@@ -1,0 +1,6 @@
+import groovy.transform.*
+import org.olf.licenses.LicenseOrg
+
+@Field LicenseOrg licenseOrg
+json g.render(licenseOrg, [expand: ['role', 'org' ]])
+


### PR DESCRIPTION
- Expand `License`'s `orgs` array field
- Expand `LicenseOrg` the same way `SubscriptionAgreementOrg` is in mod-agreements.