### PR TITLE
Tweak linkedAgreements perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The /licenses resource allows module clients to Create, Retrieve, Update and Del
 
 /licenseLinks allows service clients to list all the resources that a license is connected to. N.B. This only reports links that mod-licenses manages, not inbound resources.
 
+## ModuleDescriptor
+
+https://github.com/folio-org/mod-licenses/blob/master/service/src/main/okapi/ModuleDescriptor-template.json
+
 # For developers wanting to maintain and extend mod-licenses
 
 ## Regenerating the liquibase migrations script

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -158,7 +158,8 @@
     "subPermissions": [ 
       "licenses.licenses.collection.get",
       "licenses.licenses.item.get",
-      "licenses.licenses.item.linkedAgreements.get"
+      "licenses.licenses.item.linkedAgreements.get",
+      "licenses.agreements.linkedLicenses.get"
     ]
   },{
     "permissionName": "licenses.licenses.edit",


### PR DESCRIPTION
Added `licenses.agreements.linkedLicenses.get` to the `licenses.licenses.view` perm set. I'm not completely sure we want this, but it looks like what's needed to get the `/licenses/licenses/{id}/linkedAgreements` endpoint working for diku_admin.