### PR TITLE
PR to add localReference field to licenses

### DIFF
--- a/service/grails-app/domain/org/olf/licenses/License.groovy
+++ b/service/grails-app/domain/org/olf/licenses/License.groovy
@@ -13,6 +13,7 @@ class License extends LicenseCore implements CustomProperties,MultiTenant<Licens
 
   @Defaults(['Local', 'Consortial', 'National', 'Alliance' ])
   RefdataValue type
+  String localReference
 
   static hasMany = [
     orgs:LicenseOrg,
@@ -26,6 +27,7 @@ class License extends LicenseCore implements CustomProperties,MultiTenant<Licens
 
   static constraints = {
     type(nullable:true, blank:false)
+    localReference(nullable:true, blank:false)
     orgs (validator: { orgs ->
       int num_licensor_orgs = orgs.findAll { it.role?.value?.equalsIgnoreCase('Licensor') }.size()
       // If there is more than one licensor, return an error message relating to the i18n message validation.onlyOneLicensor
@@ -36,6 +38,7 @@ class License extends LicenseCore implements CustomProperties,MultiTenant<Licens
   static mapping = {
     type column: 'lic_type_rdv_fk'
     orgs cascade: 'all-delete-orphan'
+    localReference column: 'lic_local_reference'
     amendments cascade: 'all-delete-orphan', sort: 'startDate', order: 'desc'
   }
 }

--- a/service/grails-app/migrations/update-mod-license-2-1.groovy
+++ b/service/grails-app/migrations/update-mod-license-2-1.groovy
@@ -2,4 +2,10 @@ databaseChangeLog = {
   changeSet(author: "sosguthorpe (generated)", id: "1579605191629-1") {
     modifyDataType (tableName: 'custom_property_integer', columnName: 'value', newDataType: 'bigint')
   }
+
+  changeSet(author: "efreestone (manual)", id: "202002271345-1") {
+    addColumn(tableName: "license") {
+      column(name: "lic_local_reference", type: "varchar(128)")
+    }
+  }
 }


### PR DESCRIPTION
`localReference` field is to be used to hold LAS:eR reference data, so that we can eventually get away from relying on the naming conventions of the license. The same field name is used in agreements, and Pkg has a `reference` field we use.