### PR TITLE
FOLIO-3106: https for maven.indexdata.com

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -28,7 +28,7 @@ repositories {
 //  mavenLocal()
   jcenter()
   maven { url 'https://repo.grails.org/grails/core' }
-  maven { url 'http://maven.indexdata.com/' }
+  maven { url 'https://maven.indexdata.com/' }
   maven { url "http://maven.k-int.com/content/repositories/releases" }
 }
 


### PR DESCRIPTION
This fixes Machine-in-the-Middle (MITM) attack vulnerabilities,
for details see
https://issues.folio.org/browse/FOLIO-3106
https://issues.folio.org/browse/FOLIO-3044
https://issues.folio.org/browse/FOLIO-3045