### PR TITLE
ERM-1729: Update widget definition to remove non-required comparators

### DIFF
--- a/service/src/main/okapi/tenant/sample_data/widgetDefinitions/erm_licenses_simple_search_widget.json
+++ b/service/src/main/okapi/tenant/sample_data/widgetDefinitions/erm_licenses_simple_search_widget.json
@@ -143,7 +143,7 @@
               "label": "Open ended"
             }
           ],
-          "comparators": ["==", "!=", "isSet", "isNotSet"]
+          "comparators": ["==", "!="]
         },
         {
           "name":"internalContact",


### PR DESCRIPTION
Removes isSet and isNotSet comporators from openEnded filter as they are not effective when endDateSemantics doesn't exist