### PR TITLE
FOLIO-2898 FOLIO-2893 FOLIO-2917 Use new CI facilities api-doc and api-lint and api-schema-lint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,18 +120,12 @@ pipeline {
       }
     }
 
-    stage('Publish API Docs') {
+    stage('Generate API docs') {
       when {
         branch 'master'
       }
       steps {
-        sh "python3 /usr/local/bin/generate_api_docs.py -r ${env.name} -l info -o folio-api-docs"
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
-                          accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                          credentialsId: 'jenkins-aws',
-                          secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-          sh 'aws s3 sync folio-api-docs s3://foliodocs/api'
-        }
+        runApiDoc('RAML', 'ramls', '')
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,9 +114,9 @@ pipeline {
       }
     }
 
-    stage('Lint raml schema') {
+    stage('API schema lint') {
       steps {
-        runLintRamlSchema()
+        runApiSchemaLint('ramls', '')
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,9 @@ pipeline {
       }
     }
 
-    stage('Lint raml-cop') {
+    stage('API lint') {
       steps {
-        runLintRamlCop()
+        runApiLint('RAML', 'ramls', '')
       }
     }
 


### PR DESCRIPTION
These CI facilities replace the deprecated ones. See:
https://dev.folio.org/guides/api-lint/
https://dev.folio.org/guides/api-doc/
