### PR TITLE
FOLIO-3382 Add new api-lint warnings arg

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,11 +53,11 @@ pipeline {
       }
     }
 
-/*     stage('API lint') {
+    stage('API lint') {
       steps {
-        runApiLint('RAML', 'ramls', '')
+        runApiLint('RAML', 'ramls', '', false)
       }
-    } */
+    }
 
     stage('Gradle Build') {
       steps {


### PR DESCRIPTION
Add new [api-lint](https://dev.folio.org/guides/api-lint/) arg for warnings. False by default.

And re-enable doApiLint.