### PR TITLE
ERM-2433: Upgrade hibernate, postgresql, opencsv, minio, okhttp, kotlin

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -125,10 +125,10 @@ dependencies {
 
 //  compile 'org.grails.plugins:grails-java8:1.2.3'               // No longer needed in grails 4.
   compile "org.springframework.boot:spring-boot-starter-undertow" // Replaces spring-boot-starter-tomcat
-  compile "org.hibernate:hibernate-core:5.4.19.Final"             // Update to latest 5.4
-  compile "org.hibernate:hibernate-java8:5.4.19.Final"
+  compile "org.hibernate:hibernate-core:5.6.14.Final"             // Update to latest 5.6
+  compile "org.hibernate:hibernate-java8:5.6.14.Final"
   runtime "com.zaxxer:HikariCP:3.4.5"                             // Replaces Tomcat JDBC pool
-  runtime "org.postgresql:postgresql:42.2.14"
+  runtime "org.postgresql:postgresql:42.5.0"
 
   compile ('org.grails.plugins:database-migration:3.1.0') {       // Required by Grails Okapi
     exclude group: 'org.liquibase', module: 'liquibase-core'
@@ -136,7 +136,7 @@ dependencies {
   compile 'org.liquibase:liquibase-core:3.9.0'
   // compile 'org.liquibase:liquibase-core:3.10.1'                // Liquibase changed searchpath handling. Downgrading for now.
 
-  compile 'com.opencsv:opencsv:5.2'
+  compile 'com.opencsv:opencsv:5.7.1'
   compile 'commons-io:commons-io:2.6'
 
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'     // TODO: Migrate away from this resource.
@@ -144,9 +144,9 @@ dependencies {
   compile 'com.k_int.okapi:grails-okapi:4.1.2'
 
   // Minio for file storage to S3
-  compile "io.minio:minio:8.3.3"
-  compile 'com.squareup.okhttp3:okhttp:4.8.1'
-  compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.70'
+  compile "io.minio:minio:8.4.5"
+  compile 'com.squareup.okhttp3:okhttp:4.10.0'
+  compile 'org.jetbrains.kotlin:kotlin-stdlib:1.7.20'
 }
 
 bootRun {


### PR DESCRIPTION
Upgrade dependencies that are no longer supported and/or have known security vulnerabilities:

Upgrade hibernate-core and hibernate-java8 from 5.4.19.Final to 5.6.14.Final fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2020-25638

Hibernate 5.4 and 5.5 have reached end of life and have been unsupported since 2021-12-16, see older series at https://hibernate.org/orm/releases/

Upgrade postgresql JDBC from 42.2.14 to 42.5.0 fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197

postgresql 42.2, 42.3 and 42.4 have reached end of life and are unsupported, see https://jdbc.postgresql.org/download/

Upgrade opencsv from 5.2 to 5.7.1. This indirectly upgrades the transitive dependency commons-text from 1.8 to 1.10.0 fixing Arbitrary Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2022-42889

opencsv 5.2 has reached end of life and has been unsupported since 2020: https://sourceforge.net/p/opencsv/wiki/What%27s%20new/

Upgrade minio from 8.3.3 to 8.4.5.
Only the latest released minio version is supported: https://github.com/minio/minio/blob/master/SECURITY.md#security-policy

Upgrade okhttp from 4.8.1 to 4.10.0 fixing Information Exposure: https://app.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044

Upgrade kotlin-stdlib from 1.3.70 to 1.7.20 fixing Improper Locking and Information Exposure: https://nvd.nist.gov/vuln/detail/CVE-2022-24329
https://nvd.nist.gov/vuln/detail/CVE-2020-29582