### PR TITLE
ERM-2642: Hibernate JPA Criteria SQL Injection (CVE-2020-25638)

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,7 +1,7 @@
-configurations.all {
+/* configurations.all {
   // Check for updates every build
   resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
+} */
 
 buildscript {
   repositories {
@@ -130,8 +130,8 @@ dependencies {
 
 //  compile 'org.grails.plugins:grails-java8:1.2.3'               // No longer needed in grails 4.
   compile "org.springframework.boot:spring-boot-starter-undertow" // Replaces spring-boot-starter-tomcat
-  compile "org.hibernate:hibernate-core:5.4.19.Final"             // Update to latest 5.4
-  compile "org.hibernate:hibernate-java8:5.4.19.Final"
+  compile "org.hibernate:hibernate-core:5.4.28.Final"             // Update to latest 5.4
+  compile "org.hibernate:hibernate-java8:5.4.28.Final"
   runtime "com.zaxxer:HikariCP:3.4.5"                             // Replaces Tomcat JDBC pool
   runtime "org.postgresql:postgresql:42.5.3"
 


### PR DESCRIPTION
build: hibernate patch deps

Small bump to hibernate-core and hibernate-java8 to bring up to patch 28 and remove SQL injection vulnerability

ERM-2642