### PR TITLE
ERM-2940: spring-webmvc 5.3.25 security bypass vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 .*
 !.gitignore
 !.github
+
+ConsoleOutput.txt

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -140,8 +140,8 @@ dependencies {
 	compileOnly 'ch.qos.logback:logback-classic:1.4.7'
 
 	/*  ---- Manually installed testing dependencies ---- */
-	implementation "org.grails:grails-gorm-testing-support:2.6.1"
-	implementation "org.grails:grails-web-testing-support:2.6.1"
+	testImplementation "org.grails:grails-gorm-testing-support:2.6.1"
+	testImplementation "org.grails:grails-web-testing-support:2.6.1"
 	testImplementation "org.grails.plugins:geb"
 	testImplementation "org.seleniumhq.selenium:selenium-remote-driver:3.14.0"
 	testImplementation "org.seleniumhq.selenium:selenium-api:3.14.0"
@@ -156,6 +156,9 @@ dependencies {
 	testImplementation( 'com.athaydes:spock-reports:2.3.2-groovy-3.0' ) {
 		transitive = false // this avoids affecting your version of Groovy/Spock
 	}
+
+	// Bumping this manually to avoid potential security issue with spring-webmvc-5.3.25
+	implementation 'org.springframework:spring-webmvc:5.3.28'
 }
 
 bootRun {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -140,8 +140,8 @@ dependencies {
 	compileOnly 'ch.qos.logback:logback-classic:1.4.7'
 
 	/*  ---- Manually installed testing dependencies ---- */
-	testImplementation "org.grails:grails-gorm-testing-support:2.6.1"
-	testImplementation "org.grails:grails-web-testing-support:2.6.1"
+	implementation "org.grails:grails-gorm-testing-support:2.6.1"
+	implementation "org.grails:grails-web-testing-support:2.6.1"
 	testImplementation "org.grails.plugins:geb"
 	testImplementation "org.seleniumhq.selenium:selenium-remote-driver:3.14.0"
 	testImplementation "org.seleniumhq.selenium:selenium-api:3.14.0"


### PR DESCRIPTION
build: spring-webmvc

Directly implemented dep on spring-webmvc 5.3.28 to avoid possible security vulnerability

refs ERM-2940