### PR TITLE
ERM-2961 Extend length of document URL to 2048 chars

### DIFF
--- a/service/grails-app/migrations/docs.groovy
+++ b/service/grails-app/migrations/docs.groovy
@@ -72,4 +72,11 @@ databaseChangeLog = {
     }
   }
 
+  // extend document_attachment's url field to 2048 characters
+  changeSet(author: "Claudia (manual)", id: "20230703-001") {
+    modifyDataType (
+      tableName: "document_attachment",
+      columnName: "da_url",
+      newDataType: "varchar(2048)")
+  }
 }


### PR DESCRIPTION
* add modifyDataType changeSet to docs.groovy migrations