### PR TITLE
Release 5.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 5.0.3 2024-05-03
+  * ERM-3138 Poppy: grails 5.3.6 fixing databinding DoS (CVE-2023-46131)
+
 ## 5.0.2 2023-11-23
   * ERM-3112 org.json:json:20201115 DoS/OOM
 

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -1,11 +1,11 @@
-grailsVersion=5.3.2
-grailsGradlePluginVersion=5.3.0
+grailsVersion=5.3.6
+grailsGradlePluginVersion=5.3.1
 groovyVersion=3.0.11
 gorm.version=7.3.3
 
 # Application
 appName=mod-licenses
-appVersion=5.0.2
+appVersion=5.0.3
 dockerTagSuffix=
 dockerRepo=folioci
 

--- a/service/grails-app/conf/application-dc.yml
+++ b/service/grails-app/conf/application-dc.yml
@@ -1,0 +1,34 @@
+##
+# This config file connects to the postgres install from a rancher desktop instance.
+# Use the flag '-Dgrails.env=rancher-desktop-db' when running
+##
+
+dataSource:
+  dbCreate: none
+  url: "jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${db.database:okapi_modules_test}" # Port 5432 forwarded so as not to clash.
+  username: postgres
+  password: pa55w0rd
+  driverClassName: org.postgresql.Driver
+  dialect: com.k_int.hibernate.dialects.postgres.KIPostgres94Dialect
+  schemaHandler: com.k_int.okapi.OkapiSchemaHandler
+  logSql: false
+  properties:
+      jmxEnabled: false
+      maximumPoolSize: ${db.maxpoolsize:10}
+      transactionIsolation: TRANSACTION_READ_COMMITTED
+  hibernate:
+    enable_lazy_load_no_trans: true
+
+okapi: 
+  service:
+    host: localhost
+    port: 30100
+logging:
+  config: classpath:logback-development.xml
+
+
+
+#    register: true
+#    deploy: true
+        
+      


### PR DESCRIPTION
build: Poppy: grails 5.3.6 fixing databinding DoS (https://github.com/advisories/GHSA-3pjv-r7w4-2cf5)

Fixed grails version pulling in databinding library with security issue. Included application-dc profile yaml

ERM-3138