### PR TITLE
ERM-3387: Description can be too long for index, causing mod-licenses error when updating from 5.0.x to later versions or failure on saving licenses with a long description

### DIFF
--- a/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
+++ b/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
@@ -21,7 +21,7 @@ databaseChangeLog = {
 		// Gin indexes need to be done via scripting.
 		grailsChange {
 			change {
-				def cmd = "CREATE INDEX alternate_name_name_idx ON ${database.defaultSchemaName}.alternate_name USING gin (an_name, gin_trgm_ops);".toString()
+				def cmd = "CREATE INDEX alternate_name_name_idx ON ${database.defaultSchemaName}.alternate_name USING gin (an_name gin_trgm_ops);".toString()
 				sql.execute(cmd);
 			}
 		}
@@ -35,7 +35,7 @@ databaseChangeLog = {
 		}
 		grailsChange {
 			change {
-				def cmd = "CREATE INDEX license_name_idx ON ${database.defaultSchemaName}.license USING gin (lic_name, gin_trgm_ops);".toString()
+				def cmd = "CREATE INDEX license_name_idx ON ${database.defaultSchemaName}.license USING gin (lic_name gin_trgm_ops);".toString()
 				sql.execute(cmd);
 			}
 		}
@@ -49,7 +49,7 @@ databaseChangeLog = {
 		}
 		grailsChange {
 			change {
-				def cmd = "CREATE INDEX license_description_idx ON ${database.defaultSchemaName}.license USING gin (lic_description, gin_trgm_ops);".toString()
+				def cmd = "CREATE INDEX license_description_idx ON ${database.defaultSchemaName}.license USING gin (lic_description gin_trgm_ops);".toString()
 				sql.execute(cmd);
 			}
 		}

--- a/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
+++ b/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
@@ -1,0 +1,57 @@
+databaseChangeLog = {
+  /* GIN Indexes have been added in update-mod-licenses-5-1.groovy
+   * These can cause issues when the underlying data passes a certain limit
+   * due to trigram operator not being used and the postgres token size growing
+   *
+   * It is a little unorthodox, however these index creations are conditional on
+   * "CREATE IF NOT EXISTS". We will make use of that to insert indices on those
+   * fields _before_ they are set up by upgrading/new implementors. For any tenants
+   * who already managed to upgrade, these new changesets will be ignored, but it
+   * it _recommended_ that an operational task be undertaken to bring those schemas
+   * in line with the indices in place on new instances of mod-agreements
+   */
+
+  // The first two of these shouldn't be impacted by the bug outlined in ERM-3387, but we bring them in line anyway
+  changeSet(author: "EFreestone (manual)", id: "2024-10-17-ERM-3387-quesnalia-1") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'alternate_name', columnNames: 'an_name')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX alternate_name_name_idx ON ${database.defaultSchemaName}.alternate_name USING gin (an_name, gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-10-17-ERM-3387-quesnalia-2") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'license', columnNames: 'lic_name')
+			}
+		}
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX license_name_idx ON ${database.defaultSchemaName}.license USING gin (lic_name, gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+	}
+
+  changeSet(author: "EFreestone (manual)", id: "2024-10-17-ERM-3387-quesnalia-3") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'license', columnNames: 'lic_description')
+			}
+		}
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX license_description_idx ON ${database.defaultSchemaName}.license USING gin (lic_description, gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+	}
+}

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -21,5 +21,6 @@ databaseChangeLog = {
   include file: 'wtk/hidden-appsetting.feat.groovy'
   include file: 'update-mod-license-4-2.groovy'
   include file: 'wtk/multi-value-custprops.feat.groovy'
+  include file: 'correct-gin-indices-pre-quesnalia.groovy'
   include file: 'update-mod-license-5-1.groovy'
 }


### PR DESCRIPTION
Added pre-quesnalia migration file which intercepts the broken migration by implementing it correctly for systems struggling to upgrade.

It won't run for systems who have _already_ upgraded, and so those will have issues attempting to post sufficiently large license descriptions. Release notes should include description of this issue, and we can help to remedy it with SQL.


(This is left deliberately to implementors, not as automagical migrations, as implementors often include and manage their own indexes in addition to those set up automatically, which we have no insight into)