### PR TITLE
ERM-3420: Missing interface dependencies in module descriptor in mod-licenses

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -1,6 +1,16 @@
 {
   "id": "${info.app.name}-${info.app.version}",
   "name": "${info.app.name}",
+  "optional": [
+    {
+      "id": "erm",
+      "version": "7.0"
+    },
+    {
+      "id": "organizations.organizations",
+      "version": "1.0"
+    }
+  ],
   "provides": [
     {
       "id": "licenses",


### PR DESCRIPTION
build: Add optional okapi dependencies to ModuleDescriptor

ERM-3420