### PR TITLE
ERM-3470: S3 environment variable settings

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -133,7 +133,7 @@ dependencies {
   //testImplementation("io.micronaut:micronaut-http-client")
 
   /*  ---- Manually installed dependencies ---- */
-	implementation 'com.k_int.grails:web-toolkit-ce:10.0.1'
+	implementation 'com.k_int.grails:web-toolkit-ce:10.1.0'
 	implementation('com.k_int.okapi:grails-okapi:7.3.0') {
     exclude group: 'com.vaadin.external.google', module: 'android-json'
   }


### PR DESCRIPTION
feat: S3 Environment variable

Now available via WTK 10.1.0 -- the ability to set a GLOBAL_S3_SECRET_KEY which acts as a _fallback_ for all tenants if the pre-existing AppSetting is not set.

refs ERM-3470