### PR TITLE
ERM-3470: fix -- remove S3 environment variable string fallback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 
   agent {
     node {
-      label 'jenkins-agent-java17'
+      label 'jenkins-agent-java17-bigmem'
     }
   }
 

--- a/service/grails-app/services/org/olf/licenses/LicenseHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/licenses/LicenseHousekeepingService.groovy
@@ -118,7 +118,7 @@ public class LicenseHousekeepingService {
             [ 'fileStorage', 'storageEngine', 'String', 'FileStorageEngines', 'LOB' ],
             [ 'fileStorage', 'S3Endpoint',    'String', null,                 default_aws_url ?: 'http://s3_endpoint_host.domain:9000' ],
             [ 'fileStorage', 'S3AccessKey',   'String', null,                 default_aws_access_key_id ?: 'ACCESS_KEY' ],
-            [ 'fileStorage', 'S3SecretKey',   'String', null,                 default_aws_secret ?: 'SECRET_KEY' ],
+            [ 'fileStorage', 'S3SecretKey',   'String', null,                 default_aws_secret ],
             [ 'fileStorage', 'S3BucketName',  'String', null,                 default_aws_bucket ?: "${tenantId}-shared" ],
             [ 'fileStorage', 'S3BucketRegion','String', null,                 default_aws_region ?: "us-east-1" ],
             [ 'fileStorage', 'S3ObjectPrefix','String', null,                 "/${tenantId}/licenses/" ],


### PR DESCRIPTION
build: Remove string fallbacks for S3 env variable

S3 environment variable should be `null` when it has not been configured.

refs ERM-3470