### PR TITLE
ERM-3688: minio 8.5.17, kafka-clients 3.7.2, jackson 2.18.3 fixing vulns

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -79,6 +79,8 @@ configurations {
   mainClass = "org.olf.licenses.Application"
 } */
 
+ext['jackson.version'] = '2.18.3'
+
 dependencies {
   /* ---- Grails 6 ---- */
   compileOnly("io.micronaut:micronaut-inject-groovy")
@@ -157,7 +159,7 @@ dependencies {
   runtimeOnly 'ch.qos.logback:logback-classic:1.2.13'
 
   // Minio for file storage to S3 (reflects mod-agreements)
-  implementation "io.minio:minio:8.5.1"
+  implementation "io.minio:minio:8.5.17"
   implementation 'com.squareup.okhttp3:okhttp:4.10.0'
   implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
 
@@ -172,7 +174,7 @@ dependencies {
 	implementation "org.seleniumhq.selenium:selenium-firefox-driver:3.14.0"
 
 	/* ---- Custom non profile deps ---- */
-  implementation 'org.apache.kafka:kafka-clients:3.7.0'
+  implementation 'org.apache.kafka:kafka-clients:3.7.2'
   implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
 
 	// Better test reports.


### PR DESCRIPTION
Bumped dependencies for minio, kafka-clients and jackson, fixing vulnerabilities

ERM-3688