### PR TITLE
ERM-3730: spring-security-core/-web 5.8.16, spring-expression 5.3.39

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -113,9 +113,12 @@ dependencies {
   implementation("org.grails.plugins:events")
   implementation("org.grails.plugins:hibernate5")
   implementation("org.grails.plugins:spring-security-core:6.1.1") // NOT IN LINE WITH GRAILS PATCH VERSION
-  // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
-  implementation("org.springframework.security:spring-security-core:5.8.11")
-  
+  // 5.8.15 of spring-security-core and spring-security-web are affected by https://spring.io/security/cve-2024-38827
+  implementation("org.springframework.security:spring-security-core:5.8.16")
+  implementation("org.springframework.security:spring-security-web:5.8.16")
+  // 5.3.38 is affected by https://spring.io/security/cve-2024-38808
+  implementation("org.springframework:spring-expression:5.3.39")
+
   implementation("org.grails.plugins:views-json")
   implementation("org.grails.plugins:views-json-templates")
   implementation("org.hibernate:hibernate-core:5.6.15.Final")


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3730

Upgrade org.springframework.security:spring-security-core and org.springframework.security:spring-security-web
from 5.8.11 to 5.8.16 fixing https://spring.io/security/cve-2024-38827

Upgrade org.springframework:spring-expression from 5.3.31 to 5.3.39 fixing https://spring.io/security/cve-2024-38808