### PR TITLE
ERM-3732: okhttp 4.12.0, okio 3.6.0, okio-jvm 3.6.0

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -174,7 +174,7 @@ dependencies {
 
   // Minio for file storage to S3 (reflects mod-agreements)
   implementation "io.minio:minio:8.5.17"
-  implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
   implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
 
 	/*  ---- Manually installed testing dependencies ---- */


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3732

Upgrade okhttp from 4.10.0 to 4.12.0.

This indirectly upgrades the transitive dependencies okio and okio-jvm from 3.0.0 to 3.6.0 fixing this vulnerability:

* https://nvd.nist.gov/vuln/detail/CVE-2023-3635