### PR TITLE
ERM-3733: spring-web 5.3.39, spring-webmvc 5.3.39 fixing vulns

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -115,7 +115,11 @@ dependencies {
   implementation("org.grails.plugins:spring-security-core:6.1.1") // NOT IN LINE WITH GRAILS PATCH VERSION
   // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
   implementation("org.springframework.security:spring-security-core:5.8.11")
-  
+  // fix multiple vulns https://security.snyk.io/package/maven/org.springframework%3Aspring-web
+  implementation("org.springframework:spring-web:5.3.39")
+  // fix multiple vulns https://security.snyk.io/package/maven/org.springframework%3Aspring-webmvc
+  implementation("org.springframework:spring-webmvc:5.3.39")
+
   implementation("org.grails.plugins:views-json")
   implementation("org.grails.plugins:views-json-templates")
   implementation("org.hibernate:hibernate-core:5.6.15.Final")


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3733

Upgrade spring-web from 5.3.31 to 5.3.39.

Upgrade spring-webmvc from 5.3.31 to 5.3.39.

These upgrades fixes multiple vulnerabilities:

* https://security.snyk.io/package/maven/org.springframework%3Aspring-web
* https://security.snyk.io/package/maven/org.springframework%3Aspring-webmvc