### PR TITLE
ERM-3874. ERM - License App CSV export issue

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -327,6 +327,13 @@ tasks.withType(Test) {
   systemProperty "geb.build.reportsDir", reporting.file("geb/integrationTest")
   systemProperty "webdriver.chrome.driver", System.getProperty('webdriver.chrome.driver')
   systemProperty "webdriver.gecko.driver", System.getProperty('webdriver.gecko.driver')
+
+  afterSuite { desc, result ->
+    if (!desc.parent) {
+      logger.lifecycle "Test result: ${result.resultType} (${result.testCount} tests, " +
+        "${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+    }
+  }
 }
 
 /**

--- a/service/grails-app/controllers/org/olf/licenses/export/ExportController.groovy
+++ b/service/grails-app/controllers/org/olf/licenses/export/ExportController.groovy
@@ -5,6 +5,7 @@ import com.k_int.okapi.OkapiTenantAwareController
 import com.opencsv.CSVWriterBuilder
 import com.opencsv.ICSVWriter
 import grails.gorm.multitenancy.CurrentTenant
+import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 
 /**
@@ -22,20 +23,15 @@ class ExportController extends OkapiTenantAwareController<License> {
     }
 
     def index() {
-        def objToBind = getObjectToBind()
+        // Parse with JsonSlurper to preserve client key order — Grails' default
+        // request.JSON is a HashMap-backed JSONObject that reorders keys.
+        Map objToBind = parseJsonBody()
 
         ExportControlObject exportObj = new ExportControlObject()
 
-        /**
-         * we want to bind this directly with bindData,
-         * but the exportObj stayed empty, so these next 3 lines were necessary
-         * we should investigate and refactor this later
-         */
         exportObj.ids = objToBind?.ids ?: []
         exportObj.include = objToBind?.include ?: [:]
         exportObj.terms = objToBind?.terms ?: [:]
-
-        bindData exportObj, objToBind
 
         log.debug("ExportController::index")
 
@@ -65,5 +61,12 @@ class ExportController extends OkapiTenantAwareController<License> {
                 log.error("Failed to close the OutputStreamWriter: ${e.message}", e)
             }
         }
+    }
+
+    private Map parseJsonBody() {
+        String body = request.reader.text
+        if (!body) return [:]
+        def parsed = new JsonSlurper().parseText(body)
+        parsed instanceof Map ? (Map) parsed : [:]
     }
 }

--- a/service/grails-app/services/org/olf/licenses/export/ExportService.groovy
+++ b/service/grails-app/services/org/olf/licenses/export/ExportService.groovy
@@ -64,72 +64,52 @@ public class ExportService {
   private void writeHeader (final ICSVWriter csvWriter, final ExportControlObject exportData) {
 
     List<String> result = []
-    for ( Map.Entry<String, Boolean> property : exportData.include ) {
-      if (property.key != 'customProperties' && property.value == true) {
-        result << property.key
-      }
-    }
-    if (exportData.include?.customProperties) {
-      for (Map.Entry<String, Boolean> custProp : exportData.include.customProperties as Map) {
-        if (custProp.value == true) {
-          // Output the property parts.
-          for (String propPart : ExportControlObject.CUST_PROP_PART_ORDER) {
-            
-            if ( exportData.terms?.get(propPart) == true ) {
-            
-              if (propPart == 'value') {
-                result << custProp.key
-              } else {            
-                result << ("${custProp.key}:${propPart}" as String)
-              }
-            }
-          }
+    result.addAll(exportData.orderedRootKeys)
+
+    List<String> termParts = exportData.orderedTermParts
+    for (String custPropKey : exportData.orderedCustomPropertyKeys) {
+      for (String propPart : termParts) {
+        if (propPart == 'value') {
+          result << custPropKey
+        } else {
+          result << ("${custPropKey}:${propPart}" as String)
         }
       }
     }
-    
+
     csvWriter.writeNext(result as String[])
   }
-  
+
   private void writeLicenseAsCSV (final ICSVWriter csvWriter, final License license, final ExportControlObject exportData) {
     List<String> result = []
-    for (final Map.Entry<String, ?> property : exportData.include) {
-      if (property.key != 'customProperties' && property.value == true) {
-        result << rootProperty ( license, property.key )
-      }
+    for (String propertyName : exportData.orderedRootKeys) {
+      result << rootProperty(license, propertyName)
     }
-    
-    if (exportData.include?.customProperties) {
-      // Also output the terms.
-      for (Map.Entry<String, Boolean> custProp : exportData.include.customProperties as Map) {
-        if (custProp.value == true) {
-          // Output the property.
-          result.addAll( customProperty( license, custProp.key, exportData ) )
-        }
-      }
+
+    List<String> termParts = exportData.orderedTermParts
+    for (String custPropKey : exportData.orderedCustomPropertyKeys) {
+      result.addAll(customProperty(license, custPropKey, termParts))
     }
-    
+
     csvWriter.writeNext(result as String[])
   }
-  
+
   private String rootProperty(final License license, final String propertyName) {
     handleValue (license[propertyName])
   }
-  
-  private List<String> customProperty(final License license, final String propertyName, final ExportControlObject exportData) {
-    
+
+  private List<String> customProperty(final License license, final String propertyName, final List<String> termParts) {
+
     // Find the first instance.
     CustomProperty prop = license.customProperties?.value?.find( { CustomProperty cp -> cp.definition.name == propertyName} )
-    
-    // Output the property parts.
+
+    // Output the property parts in the same order used by writeHeader so
+    // headers and row values stay aligned column-for-column.
     List<String> result = []
-    for (String propPart : ExportControlObject.CUST_PROP_PART_ORDER) {
-      
-      if ( exportData.terms?.get(propPart) == true ) {
-        result << handleValue ( prop?.getAt(propPart))
-      }
+    for (String propPart : termParts) {
+      result << handleValue ( prop?.getAt(propPart))
     }
-    
+
     result
   }
   

--- a/service/src/main/groovy/org/olf/licenses/export/ExportControlObject.groovy
+++ b/service/src/main/groovy/org/olf/licenses/export/ExportControlObject.groovy
@@ -1,65 +1,49 @@
 package org.olf.licenses.export
 
-import grails.databinding.BindUsing
-import grails.databinding.BindingHelper
-import grails.databinding.DataBindingSource
 import grails.validation.Validateable
 import groovy.transform.CompileStatic
 
-@BindUsing(ExportControlObject.Binder)
 @CompileStatic
 class ExportControlObject implements Validateable {
-  
-  public static final List<String> CUST_PROP_PART_ORDER = [ 'value', 'internal', 'note', 'publicNote' ] 
-  
-  List<String> ids = []
-  LinkedHashMap<String, ?> include = [:] 
-  Map<String, Boolean> terms = [:]
-  
-//  private List<String> rootPropertyOrder = null
-//  List<String> getRootPropertyOrder() {
-//    if (rootPropertyOrder == null) {
-//      rootPropertyOrder = []
-//      if (include) {
-//        rootPropertyOrder.addAll(include.keySet().findResults({ it != 'customProperties' ? it : null }))
-//      }
-//    }
-//    
-//    rootPropertyOrder
-//  }
-//  
-//  private List<String> customPropertyOrder = null
-//  List<String> getCustomPropertyOrder() {
-//    if (customPropertyOrder == null) {
-//      customPropertyOrder = []
-//      if (include) {
-//        customPropertyOrder.addAll(include.keySet())
-//      }
-//    }
-//    customPropertyOrder
-//  }
-  
-  private static class Binder implements BindingHelper {
 
-    @Override
-    public Object getPropertyValue(final Object obj, final String propertyName, final DataBindingSource source) {
-      
-      def propVal = obj[propertyName]
-      
-      switch (propertyName) {
-        case "ids" :
-          (propVal as Collection).addAll(source.getPropertyValue(propertyName) as Collection)
-          break
-        case 'include':
-        case 'terms':
-          (propVal as Map).putAll(source.getPropertyValue(propertyName) as Map)
-          break
-        default: 
-          propVal = source.getPropertyValue(propertyName)
+  List<String> ids = []
+  LinkedHashMap<String, ?> include = [:]
+  LinkedHashMap<String, Boolean> terms = [:]
+
+  /** Root License property keys to export, in caller order. */
+  List<String> getOrderedRootKeys() {
+    if (!include) return []
+    List<String> result = []
+    for (Map.Entry<String, ?> entry : include.entrySet()) {
+      if (entry.key != 'customProperties' && entry.value == true) {
+        result.add(entry.key)
       }
-      
-      propVal
     }
-    
+    result
+  }
+
+  /** Custom-property keys to export, in caller order. */
+  List<String> getOrderedCustomPropertyKeys() {
+    Object raw = include?.get('customProperties')
+    if (!(raw instanceof Map)) return []
+    List<String> result = []
+    for (Map.Entry<?, ?> entry : ((Map<?, ?>) raw).entrySet()) {
+      if (entry.value == true) {
+        result.add(entry.key as String)
+      }
+    }
+    result
+  }
+
+  /** Term sub-columns to export, in caller order. */
+  List<String> getOrderedTermParts() {
+    if (!terms) return []
+    List<String> result = []
+    for (Map.Entry<String, Boolean> entry : terms.entrySet()) {
+      if (entry.value == true) {
+        result.add(entry.key)
+      }
+    }
+    result
   }
 }

--- a/service/src/test/groovy/org/olf/licenses/export/ExportControlObjectSpec.groovy
+++ b/service/src/test/groovy/org/olf/licenses/export/ExportControlObjectSpec.groovy
@@ -1,0 +1,122 @@
+package org.olf.licenses.export
+
+import spock.lang.Specification
+
+class ExportControlObjectSpec extends Specification {
+
+  void 'getOrderedRootKeys preserves caller iteration order'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [
+      endDate  : true,
+      name     : true,
+      type     : true,
+      startDate: true,
+      status   : true,
+    ] as LinkedHashMap
+
+    expect:
+    obj.orderedRootKeys == ['endDate', 'name', 'type', 'startDate', 'status']
+  }
+
+  void 'getOrderedRootKeys skips customProperties and entries whose value is not true'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [
+      name            : true,
+      description     : false,
+      type            : true,
+      customProperties: [foo: true] as LinkedHashMap,
+    ] as LinkedHashMap
+
+    expect:
+    obj.orderedRootKeys == ['name', 'type']
+  }
+
+  void 'getOrderedRootKeys returns empty list for empty include'() {
+    expect:
+    new ExportControlObject().orderedRootKeys == []
+  }
+
+  void 'getOrderedRootKeys returns empty list for null include'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = null
+
+    expect:
+    obj.orderedRootKeys == []
+  }
+
+  void 'getOrderedCustomPropertyKeys preserves caller iteration order'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [
+      customProperties: [
+        remoteAccess    : true,
+        illElectronic   : true,
+        concurrentAccess: true,
+        illNotes        : true,
+      ] as LinkedHashMap,
+    ] as LinkedHashMap
+
+    expect:
+    obj.orderedCustomPropertyKeys == ['remoteAccess', 'illElectronic', 'concurrentAccess', 'illNotes']
+  }
+
+  void 'getOrderedCustomPropertyKeys skips custom properties whose value is not true'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [
+      customProperties: [
+        concurrentAccess: true,
+        remoteAccess    : false,
+        illNotes        : true,
+      ] as LinkedHashMap,
+    ] as LinkedHashMap
+
+    expect:
+    obj.orderedCustomPropertyKeys == ['concurrentAccess', 'illNotes']
+  }
+
+  void 'getOrderedCustomPropertyKeys returns empty list when include is empty'() {
+    expect:
+    new ExportControlObject().orderedCustomPropertyKeys == []
+  }
+
+  void 'getOrderedCustomPropertyKeys returns empty list when include has no customProperties'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [name: true] as LinkedHashMap
+
+    expect:
+    obj.orderedCustomPropertyKeys == []
+  }
+
+  void 'getOrderedCustomPropertyKeys returns empty list when customProperties is not a Map'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.include = [customProperties: true] as LinkedHashMap
+
+    expect:
+    obj.orderedCustomPropertyKeys == []
+  }
+
+  void 'getOrderedTermParts preserves caller order and filters out false'() {
+    given:
+    ExportControlObject obj = new ExportControlObject()
+    obj.terms = [
+      publicNote: true,
+      value     : true,
+      note      : false,
+      internal  : true,
+    ] as LinkedHashMap
+
+    expect:
+    obj.orderedTermParts == ['publicNote', 'value', 'internal']
+  }
+
+  void 'getOrderedTermParts returns empty list when terms is empty'() {
+    expect:
+    new ExportControlObject().orderedTermParts == []
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3874

## Summary

  Fixes a CSV column-ordering bug reported by Nagoya University where License
  fields appeared in the wrong order (e.g. `endDate → name → type → startDate`)
  and field values landed under unrelated headers (ILL notes data under the
  endDate column).

  ## Root cause

  `ExportController.index()` called `getObjectToBind()`, which returns Grails'
  `org.grails.web.json.JSONObject`. In grails-web-common 6.2.3 this class is
  backed by a plain `java.util.HashMap`, so JSON key order from the request was
  lost before reaching the export logic. Iteration over `include` then produced
  columns in hash order.

  ## Changes

  - `ExportController` — parse the request body with `JsonSlurper`, which
    returns `LinkedHashMap`s and preserves client key order end-to-end. Drops
    the now-redundant `bindData` call.
  - `ExportControlObject` — adds `orderedRootKeys`, `orderedCustomPropertyKeys`,
    and `orderedTermParts` getters that filter for `value == true` while
    preserving iteration order. Removes the obsolete `@BindUsing` annotation
    and `Binder` inner class.
  - `ExportService` — `writeHeader` and `writeLicenseAsCSV` now iterate via the
    same three getters, so header columns and row values are aligned by
    construction rather than by parallel ad-hoc loops.
  - `service/build.gradle` — adds a one-line `Test result: ...` summary after
    each test task, since the project did not previously have unit tests and
    the pass/fail outcome was hard to spot.
